### PR TITLE
Add URLs for translation states and text flow data

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -40,7 +40,7 @@
   "indent": 2,
 
   // Prohibit use of a variable before it is defined.
-  "latedef": true,
+  "latedef": "nofunc",
 
   // Enforce line length to 80 characters
   "maxlen": 80,

--- a/app/components/util/UrlService.js
+++ b/app/components/util/UrlService.js
@@ -9,45 +9,38 @@
    */
   function UrlService($location) {
     var gravatarBaseUrl = 'http://www.gravatar.com/avatar';
-
-    var userUrl = '/user';
-
-    var projectUrl = '/projects/p/:projectSlug';
-    var versionUrl = '/projects/p/:projectSlug/iterations/i/:versionSlug';
-    var statisticUrl = '/stats/proj/:projectSlug/iter/:versionSlug';
-
-    function getLocalHost() {
-      if (!window.location.origin) {
-        return window.location.protocol + '//' + window.location.hostname +
-          (window.location.port ? ':' + window.location.port : '');
-      }
-      return window.location.origin;
-    }
-
-    var translationsURL = getLocalHost() + '/translations';
-
     //TODO: get from document, configuration or URL
     var baseUrl = 'http://localhost:7878/zanata/rest';
 
-    /**
-     * Create a REST URL by appending all the given URL part arguments to the
-     * base URL.
-     *
-     * No separators will be added or removed, so all parts should include
-     * leading / and exclude trailing / to avoid problems.
-     */
-    function constructRestUrl() {
-      return baseUrl + Array.prototype.join.call(arguments, '');
-    }
+    // URLs over multiple lines are hard to read, allowing long lines here.
+    // Warnings for jshint are turned off/on with -/+ before the warning code.
+    // See: https://github.com/jshint/jshint/blob/2.1.4/src/shared/messages.js
+    /* jshint -W101 */
+    var urls = {
+      project:   restUrl('/projects/p/:projectSlug'),
+      locales:   restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug/locales'),
+      docs:      restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug/r'),
+      states:    restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug/r/:docId/states/:localeId'),
+      textFlows: restUrl('/source+trans/:localeId'),
+      docStats:  restUrl('/stats/proj/:projectSlug/iter/:versionSlug/doc/:docId/locale/:localeId'),
+      myInfo:    restUrl('/user'),
+      userInfo:  restUrl('/user/:username')
+    };
+    /* jshint +W101 */
+
+
+    var translationsURL = getLocalHost() + '/translations';
+
 
     return {
-      PROJECT_URL : constructRestUrl(projectUrl),
-      LOCALE_LIST_URL : constructRestUrl(versionUrl, '/locales'),
-      DOCUMENT_LIST_URL : constructRestUrl(versionUrl, '/r'),
-      DOC_STATISTIC_URL : constructRestUrl(statisticUrl,
-          '/doc/:docId/locale/:localeId'),
-      MY_INFO_URL : constructRestUrl(userUrl),
-      USER_INFO_URL : constructRestUrl(userUrl, '/:username'),
+      PROJECT_URL : urls.project,
+      LOCALE_LIST_URL : urls.locales,
+      DOCUMENT_LIST_URL : urls.docs,
+      TRANSLATION_STATES_URL: urls.states,
+      TEXT_FLOWS_URL: urls.textFlows,
+      DOC_STATISTIC_URL : urls.docStats,
+      MY_INFO_URL : urls.myInfo,
+      USER_INFO_URL : urls.userInfo,
 
       /**
        * Get the value of a query string parameter.
@@ -69,6 +62,25 @@
         return translationsURL + '/locales';
       }
     };
+
+    /**
+     * Create a REST URL by appending all the given URL part arguments to the
+     * base URL.
+     *
+     * No separators will be added or removed, so all parts should include
+     * leading / and exclude trailing / to avoid problems.
+     */
+    function restUrl() {
+      return baseUrl + Array.prototype.join.call(arguments, '');
+    }
+
+    function getLocalHost() {
+      if (!window.location.origin) {
+        return window.location.protocol + '//' + window.location.hostname +
+          (window.location.port ? ':' + window.location.port : '');
+      }
+      return window.location.origin;
+    }
   }
 
   angular.module('app').factory('UrlService', UrlService);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-csso": "^0.2.9",
     "gulp-debug": "^1.0.0",
     "gulp-imagemin": "^0.1.5",
-    "gulp-jshint": "^1.5.1",
+    "gulp-jshint": "^1.8.4",
     "gulp-ng-annotate": "^0.3.0",
     "gulp-notify": "^1.2.4",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
Adds 2 URLs to UrlService, and adds another helper function for building up REST URLs.

I am unsure which approach is better for describing a set of URLs: defining a URL and extending it or defining each URL in full.

Defining each in full can be fairly readable if they are manually aligned:

```
var projectUrl   = restUrl('/projects/p/:projectSlug'),
    versionUrl   = restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug'),
    documentsUrl = restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug/r'),
    documentUrl  = restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug/r/:docId'),
    statesUrl    = restUrl('/projects/p/:projectSlug/iterations/i/:versionSlug/r/:docId/states/:localeId');
```

but they get much harder to read if the alignment is out by one or two characters, particularly once you start defining several endpoints that branch from the same base.

Extending endpoints can be much more concise, and captures the essential information for an endpoint, but makes it a bit more work to figure out the full URL structure. The main reason to look at the full URL structure is to figure out which properties must be defined when using the URL, such as `:projectSlug` and `:versionSlug` for `versionUrl`.

```
var projectUrl = restUrl('/projects/p/:projectSlug'),
    versionUrl = extendRestUrl(projectUrl, '/iterations/i/:versionSlug'),
    documentsUrl = extendRestUrl(versionUrl, '/r'),
    documentUrl = extendRestUrl(documentsUrl, '/:docId'),
    statesUrl = extendRestUrl(documentUrl, '/states/:localeId');
```

A third approach that doesn't seem as good as either of the others is to compose parts of each URL. This would work right now because the functions I defined to create and extend URLs are variadic:

```
var projectPart = '/projects/p/:projectSlug',
    versionPart = '/iterations/i/:versionSlug',
    documentsPart = '/r',
    documentPart = '/:docId',
    statesPart = '/states/:localeId';

var projectUrl   = restUrl(projectPart),
    versionUrl   = restUrl(projectPart, versionPart),
    documentsUrl = restUrl(projectPart, versionPart, documentsPart),
    documentUrl  = restUrl(projectPart, versionPart, documentsPart, documentPart),
    statesUrl    = restUrl(projectPart, versionPart, documentsPart, documentPart, statesPart);
```

It might make it a little easier to see which parts a URL is made up of, but it has as much repetition as just writing out each one, without the ability to see the placeholders in-place.
